### PR TITLE
Add PyDantic XML template

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The following templates are available:
 
 - `python-dataclass`: Python dataclass implementation with JSON-LD support
 - `python-pydantic`: PyDantic implementation with JSON-LD support
-- `python-sdrdm`: Python PyDantic implementation with multiple output formats
+- `python-pydantic-xml`: PyDantic implementation with XML support
 - `xml-schema`: XML schema definition
 - `json-schema`: JSON schema definition
 - `shacl`: SHACL shapes definition

--- a/src/exporters.rs
+++ b/src/exporters.rs
@@ -52,7 +52,7 @@ pub enum Templates {
     JsonSchemaAll,
     Shex,
     PythonDataclass,
-    PythonSdrdm,
+    PythonPydanticXML,
     PythonPydantic,
     MkDocs,
     Internal,
@@ -64,7 +64,7 @@ impl Display for Templates {
         match self {
             Templates::PythonDataclass => write!(f, "python-dataclass"),
             Templates::PythonPydantic => write!(f, "python-pydantic"),
-            Templates::PythonSdrdm => write!(f, "python-sdrdm"),
+            Templates::PythonPydanticXML => write!(f, "python-pydantic-xml"),
             Templates::XmlSchema => write!(f, "xml-schema"),
             Templates::Markdown => write!(f, "markdown"),
             Templates::CompactMarkdown => write!(f, "compact-markdown"),
@@ -86,7 +86,7 @@ impl FromStr for Templates {
     fn from_str(s: &str) -> Result<Self, Box<dyn Error>> {
         match s {
             "python-dataclass" => Ok(Templates::PythonDataclass),
-            "python-sdrdm" => Ok(Templates::PythonSdrdm),
+            "python-sdrdm" => Ok(Templates::PythonPydanticXML),
             "python-pydantic" => Ok(Templates::PythonPydantic),
             "xml-schema" => Ok(Templates::XmlSchema),
             "markdown" => Ok(Templates::Markdown),
@@ -133,7 +133,7 @@ pub fn render_jinja_template(
             convert_model_types(model, &SHACL_TYPE_MAPS);
             filter_objects_wo_terms(model);
         }
-        Templates::PythonDataclass | Templates::PythonSdrdm | Templates::PythonPydantic => {
+        Templates::PythonDataclass | Templates::PythonPydanticXML | Templates::PythonPydantic => {
             convert_model_types(model, &PYTHON_TYPE_MAPS);
             sort_attributes_by_required(model);
         }
@@ -152,7 +152,7 @@ pub fn render_jinja_template(
         Templates::CompactMarkdown => env.get_template("markdown-compact.jinja")?,
         Templates::Shacl => env.get_template("shacl.jinja")?,
         Templates::Shex => env.get_template("shex.jinja")?,
-        Templates::PythonSdrdm => env.get_template("python-sdrdm.jinja")?,
+        Templates::PythonPydanticXML => env.get_template("python-pydantic-xml.jinja")?,
         Templates::MkDocs => env.get_template("mkdocs.jinja")?,
         Templates::Typescript => env.get_template("typescript.jinja")?,
         _ => {
@@ -361,12 +361,12 @@ mod tests {
     }
 
     #[test]
-    fn test_convert_to_python_sdrdm() {
+    fn test_convert_to_python_pydantic_xml() {
         // Arrange
-        let rendered = build_and_convert(Templates::PythonSdrdm);
+        let rendered = build_and_convert(Templates::PythonPydanticXML);
 
         // Assert
-        let expected = fs::read_to_string("tests/data/expected_python_sdrdm.py")
+        let expected = fs::read_to_string("tests/data/expected_python_pydantic_xml.py")
             .expect("Could not read expected file");
         assert_eq!(rendered, expected);
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -164,7 +164,7 @@ pub fn process_pipeline(path: &PathBuf) -> Result<(), Box<dyn std::error::Error>
                     Some(&specs.config),
                 )?;
             }
-            Templates::PythonSdrdm => {
+            Templates::PythonPydanticXML => {
                 serialize_by_template(
                     &specs.out,
                     paths,

--- a/templates/python-dataclass.jinja
+++ b/templates/python-dataclass.jinja
@@ -13,7 +13,7 @@
     {%- endif -%}
 {%- endmacro -%}
 
-{% import "python-sdrdm-macros.jinja" as utils %}
+{% import "python-macros.jinja" as utils %}
 ## This is a generated file. Do not modify it manually!
 
 from __future__ import annotations

--- a/templates/python-macros.jinja
+++ b/templates/python-macros.jinja
@@ -8,7 +8,7 @@
             default={%- if attr.default -%}{{ attr.default }}{%- else -%}None{%- endif -%},
             {% endif -%}
             {% if attr.multiple is true -%}
-            default_factory=ListPlus,
+            default_factory=list,
             {% endif -%}
             tag="{{ xml_tag(attr.xml) }}",
             json_schema_extra={{ create_options(attr.options, attr.term) }}

--- a/templates/python-pydantic-xml.jinja
+++ b/templates/python-pydantic-xml.jinja
@@ -1,4 +1,4 @@
-{% import "python-sdrdm-macros.jinja" as utils %}
+{% import "python-macros.jinja" as utils %}
 
 ## This is a generated file. Do not modify it manually!
 
@@ -6,24 +6,20 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 from uuid import uuid4
 from datetime import date, datetime
+from xml.dom import minidom
 
 from lxml.etree import _Element
 from pydantic import PrivateAttr, model_validator
-from pydantic_xml import attr, element
-
-import sdRDM
-from sdRDM.base.listplus import ListPlus
-from sdRDM.tools.utils import elem2dict
+from pydantic_xml import attr, element, BaseXmlModel
 
 {% for object in objects %}
 class {{object.name}}(
-    sdRDM.DataModel,
+    BaseXmlModel,
     search_mode="unordered",
 ):
     {%- for attr in object.attributes -%}
         {{ utils.create_attribute(attr) }}
     {%- endfor %}
-    _repo: str = PrivateAttr(default="{{ repo }}")
 
     {% for attr in object.attributes %}
     {%- for dtype in attr.dtypes %}
@@ -43,6 +39,22 @@ class {{object.name}}(
     {%- endif %}
     {%- endfor %}
     {%- endfor %}
+
+    def xml(self, encoding: str = "unicode") -> str | bytes:
+        """Converts the object to an XML string
+
+        Args:
+            encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
+                                      Defaults to "unicode".
+        """
+
+        if encoding == "bytes":
+            return self.to_xml()
+
+        raw_xml = self.to_xml(encoding=None)
+        parsed_xml = minidom.parseString(raw_xml)
+        return parsed_xml.toprettyxml(indent="  ")
+
 
 {% endfor %}
 {%- for enum in enums %}

--- a/templates/python-pydantic.jinja
+++ b/templates/python-pydantic.jinja
@@ -13,7 +13,7 @@
     {%- endif -%}
 {%- endmacro -%}
 
-{% import "python-sdrdm-macros.jinja" as utils %}
+{% import "python-macros.jinja" as utils %}
 ## This is a generated file. Do not modify it manually!
 
 from __future__ import annotations

--- a/tests/data/expected_python_pydantic_xml.py
+++ b/tests/data/expected_python_pydantic_xml.py
@@ -4,18 +4,15 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 from uuid import uuid4
 from datetime import date, datetime
+from xml.dom import minidom
 
 from lxml.etree import _Element
 from pydantic import PrivateAttr, model_validator
-from pydantic_xml import attr, element
-
-import sdRDM
-from sdRDM.base.listplus import ListPlus
-from sdRDM.tools.utils import elem2dict
+from pydantic_xml import attr, element, BaseXmlModel
 
 
 class Test(
-    sdRDM.DataModel,
+    BaseXmlModel,
     search_mode="unordered",
 ):
     name: str = attr(
@@ -30,7 +27,7 @@ class Test(
         )
 
     test2: list[Test2] = element(
-            default_factory=ListPlus,
+            default_factory=list,
             tag="SomeTest2",
             json_schema_extra=dict(term = "schema:something",)
         )
@@ -40,8 +37,6 @@ class Test(
             tag="ontology",
             json_schema_extra=dict()
         )
-
-    _repo: str = PrivateAttr(default="https://www.github.com/my/repo/")
 
 
     def add_to_test2(
@@ -61,13 +56,28 @@ class Test(
 
         return self.test2[-1]
 
+    def xml(self, encoding: str = "unicode") -> str | bytes:
+        """Converts the object to an XML string
+
+        Args:
+            encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
+                                      Defaults to "unicode".
+        """
+
+        if encoding == "bytes":
+            return self.to_xml()
+
+        raw_xml = self.to_xml(encoding=None)
+        parsed_xml = minidom.parseString(raw_xml)
+        return parsed_xml.toprettyxml(indent="  ")
+
 
 class Test2(
-    sdRDM.DataModel,
+    BaseXmlModel,
     search_mode="unordered",
 ):
     names: list[str] = element(
-            default_factory=ListPlus,
+            default_factory=list,
             tag="name",
             json_schema_extra=dict(term = "schema:hello",)
         )
@@ -78,7 +88,21 @@ class Test2(
             json_schema_extra=dict(term = "schema:one",minimum = "0",)
         )
 
-    _repo: str = PrivateAttr(default="https://www.github.com/my/repo/")
+
+    def xml(self, encoding: str = "unicode") -> str | bytes:
+        """Converts the object to an XML string
+
+        Args:
+            encoding (str, optional): The encoding to use. If set to "bytes", will return a bytes string.
+                                      Defaults to "unicode".
+        """
+
+        if encoding == "bytes":
+            return self.to_xml()
+
+        raw_xml = self.to_xml(encoding=None)
+        parsed_xml = minidom.parseString(raw_xml)
+        return parsed_xml.toprettyxml(indent="  ")
 
 
 class Ontology(Enum):


### PR DESCRIPTION
This PR removes the `python-sdrdm` template in favour of `python-pedantic-xml`. This template generates [pydantic-xml](                             https://pydantic-xml.readthedocs.io/en/latest/) compatible code that is capable of serializing to XML.