### PR TITLE
Add `multiple` keyword to syntax

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -73,6 +73,7 @@ impl Attribute {
             "description" => self.docstring = option.value,
             "xml" => self.set_xml(XMLType::from_str(&option.value).expect("Invalid XML type")),
             "default" => self.default = Some(DataType::from_str(&option.value)?),
+            "multiple" => self.is_array = option.value.to_lowercase() == "true",
             _ => self.options.push(option),
         }
 

--- a/tests/data/model_multiple_keyword.md
+++ b/tests/data/model_multiple_keyword.md
@@ -1,0 +1,15 @@
+---
+id-field: true
+repo: "https://www.github.com/my/repo/"
+prefix: "tst"
+prefixes:
+  schema: http://schema.org/
+nsmap:
+  tst: http://example.com/test/
+---
+
+### Test
+
+- name
+  - Type: string
+  - Multiple: True

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -301,7 +301,7 @@ mod tests {
         assert_eq!(model.objects.len(), 1);
         assert_eq!(model.enums.len(), 1);
     }
-    
+
     #[test]
     fn test_multiple_keyword() {
         // Arrange

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -301,4 +301,18 @@ mod tests {
         assert_eq!(model.objects.len(), 1);
         assert_eq!(model.enums.len(), 1);
     }
+    
+    #[test]
+    fn test_multiple_keyword() {
+        // Arrange
+        let path = Path::new("tests/data/model_multiple_keyword.md");
+
+        // Act
+        let model = DataModel::from_markdown(path).expect("Could not parse markdown");
+
+        // Assert
+        assert_eq!(model.objects.len(), 1);
+        assert_eq!(model.objects[0].attributes.len(), 1);
+        assert!(model.objects[0].attributes[0].is_array);
+    }
 }


### PR DESCRIPTION
This PR re-introduces, based on #7, the `Multiple` keyword to indicate that a given attribute is of an array type:

```
### Object

- collection
   - Type: string
   - Multiple: True
``` 