### PR TITLE
Update and extend conversion targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,12 +302,12 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "colored"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1158,7 +1158,7 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "mdmodels"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mdmodels"
 authors = ["Jan Range <jan.range@simtech.uni-stuttgart.de>"]
 description = "A tool to generate models, code and schemas from markdown files"
-version = "0.1.8"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/FAIRChemistry/md-models"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # MD-Models
 
 ![Crates.io Version](https://img.shields.io/crates/v/mdmodels) ![NPM Version](https://img.shields.io/npm/v/mdmodels-core)
@@ -73,10 +72,19 @@ The following templates are available:
 - `python-dataclass`: Python dataclass implementation with JSON-LD support
 - `python-pydantic`: PyDantic implementation with JSON-LD support
 - `python-pydantic-xml`: PyDantic implementation with XML support
+- `typescript`: TypeScript interface definitions with JSON-LD support
+- `typescript-zod`: TypeScript Zod schema definitions
+- `rust`: Rust struct definitions with serde support
+- `golang`: Go struct definitions
+- `protobuf`: Protocol Buffer schema definition
+- `graphql`: GraphQL schema definition
 - `xml-schema`: XML schema definition
 - `json-schema`: JSON schema definition
+- `json-schema-all`: Multiple JSON schema definitions (one per object)
 - `shacl`: SHACL shapes definition
 - `shex`: ShEx shapes definition
+- `compact-markdown`: Compact markdown representation
+- `mkdocs`: MkDocs documentation format
 
 ## Installation options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "mdmodels_core"
-version = "0.1.8"
+version = "0.2.0"
 description = "A tool to generate models, code and schemas from markdown files"
 requires-python = ">=3.8"
 classifiers = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@ pub mod exporters;
 pub mod pipeline;
 pub mod validation;
 
-pub(crate) mod attribute;
-pub(crate) mod object;
-pub(crate) mod xmltype;
+pub mod attribute;
+pub mod object;
+pub mod xmltype;
 
 pub mod prelude {
     pub use crate::datamodel::DataModel;
@@ -51,7 +51,7 @@ pub mod json {
 }
 
 pub(crate) mod markdown {
-    pub(crate) mod frontmatter;
+    pub mod frontmatter;
     pub(crate) mod parser;
     pub(crate) mod position;
 }

--- a/src/markdown/parser.rs
+++ b/src/markdown/parser.rs
@@ -430,6 +430,12 @@ fn extract_attribute_options(iterator: &mut OffsetIter) -> Vec<String> {
                 let last_option = options.last_mut().unwrap();
                 *last_option = format!("{}[]", last_option);
             }
+            Event::Text(text) if text.to_string() != "]" => {
+                let last_option = options.last_mut().unwrap();
+                if last_option.to_lowercase().contains("description:") {
+                    *last_option = format!("{} {}", last_option.trim(), text);
+                }
+            }
             _ => {}
         }
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -214,6 +214,51 @@ pub fn process_pipeline(path: &PathBuf) -> Result<(), Box<dyn std::error::Error>
                     Some(&specs.config),
                 )?;
             }
+            Templates::TypescriptZod => {
+                serialize_by_template(
+                    &specs.out,
+                    paths,
+                    &merge_state,
+                    &template,
+                    Some(&specs.config),
+                )?;
+            }
+            Templates::Rust => {
+                serialize_by_template(
+                    &specs.out,
+                    paths,
+                    &merge_state,
+                    &template,
+                    Some(&specs.config),
+                )?;
+            }
+            Templates::Golang => {
+                serialize_by_template(
+                    &specs.out,
+                    paths,
+                    &merge_state,
+                    &template,
+                    Some(&specs.config),
+                )?;
+            }
+            Templates::Protobuf => {
+                serialize_by_template(
+                    &specs.out,
+                    paths,
+                    &merge_state,
+                    &template,
+                    Some(&specs.config),
+                )?;
+            }
+            Templates::Graphql => {
+                serialize_by_template(
+                    &specs.out,
+                    paths,
+                    &merge_state,
+                    &template,
+                    Some(&specs.config),
+                )?;
+            }
             Templates::MkDocs => {
                 // If the template is not set to merge, then disable the navigation.
                 if let MergeState::Merge = merge_state {

--- a/templates/golang.jinja
+++ b/templates/golang.jinja
@@ -1,0 +1,203 @@
+{# Helper macros #}
+{% macro is_multiple(attr) %}
+    {%- if attr.multiple -%}[]{% endif -%}
+{% endmacro %}
+
+{% macro get_type(attr, parent_name) %}
+    {%- if attr.dtypes | length > 1 -%}
+    {{ parent_name }}{{ attr.name | capitalize }}Type
+    {%- elif attr.dtypes[0] in object_names -%}
+    {{ attr.dtypes[0] }}
+    {%- elif attr.dtypes[0] == "string" -%}
+    string
+    {%- elif attr.dtypes[0] == "float" or attr.dtypes[0] == "number" -%}
+    float64
+    {%- elif attr.dtypes[0] == "integer" -%}
+    int64
+    {%- elif attr.dtypes[0] == "boolean" -%}
+    bool
+    {%- else -%}
+    {{ attr.dtypes[0] }}
+    {%- endif -%}
+{% endmacro %}
+
+{% macro wrap_type(attr, parent_name) %}
+    {%- if attr.multiple -%}
+        []{{ get_type(attr, parent_name) }}
+    {%- else -%}
+        {{ get_type(attr, parent_name) }}
+    {%- endif -%}
+{% endmacro %}
+
+// Package {% if title -%}{{ title | lower }}{% else %}model{% endif %} contains Go struct definitions with JSON serialization.
+//
+// WARNING: This is an auto-generated file.
+// Do not edit directly - any changes will be overwritten.
+
+package {% if title -%}{{ title | lower }}{% else %}model{% endif %}
+
+import (
+    "encoding/json"
+    "fmt"
+)
+
+//
+// Type definitions
+//
+{% for object in objects %}
+{%- if object.docstring %}
+// {{ object.name }} {{ wrap(object.docstring, 70, "", "// ", None) }}
+{%- endif %}
+type {{ object.name }} struct {
+    {%- for attr in object.attributes %}
+        {%- if attr.docstring %}
+        // {{ wrap(attr.docstring, 70, "", "        // ", None) }}
+        {%- endif %}
+        {{ attr.name | capitalize }} {{ wrap_type(attr, object.name) }} `json:"{{ attr.name }}{% if attr.required is false %},omitempty{% endif %}"`
+    {%- endfor %}
+}
+{% endfor %}
+
+{%- if enums | length > 0 %}
+//
+// Enum definitions
+//
+{%- for enum in enums %}
+
+{%- if enum.docstring %}
+    // {{ enum.name }} {{ wrap(enum.docstring, 70, "", "    // ", None) }}
+{%- endif %}
+type {{ enum.name }} string
+
+const (
+    {%- for key, value in enum.mappings | dictsort %}
+    {{ enum.name }}{{ key }} {{ enum.name }} = "{{ value }}"
+    {%- endfor %}
+)
+{%- endfor %}
+{%- endif %}
+
+//
+// Type definitions for attributes with multiple types
+//
+{%- for object in objects %}
+{%- for attr in object.attributes %}
+    {%- if attr.dtypes | length > 1 %}
+
+// {{ object.name }}{{ attr.name | capitalize }}Type represents a union type that can hold any of the following types:
+{%- for dtype in attr.dtypes %}
+// - {{ dtype }}
+{%- endfor %}
+type {{ object.name }}{{ attr.name | capitalize }}Type struct {
+    {%- for dtype in attr.dtypes %}
+        {%- if dtype in object_names %}
+    Object {{ dtype }}
+        {%- elif dtype == "string" %}
+    String string
+        {%- elif dtype == "float" %}
+    Float float64
+        {%- elif dtype == "integer" %}
+    Integer int64
+        {%- elif dtype == "boolean" %}
+    Boolean bool
+        {%- else %}
+    {{ dtype | capitalize }} {{ dtype }}
+        {%- endif %}
+    {%- endfor %}
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for {{ object.name }}{{ attr.name | capitalize }}Type
+func (t *{{ object.name }}{{ attr.name | capitalize }}Type) UnmarshalJSON(data []byte) error {
+    // Reset existing values
+    {%- for dtype in attr.dtypes %}
+        {%- if dtype in object_names %}
+    t.Object = {{ dtype }}{}
+        {%- elif dtype == "string" %}
+    t.String = ""
+        {%- elif dtype == "float" %}
+    t.Float = 0
+        {%- elif dtype == "integer" %}
+    t.Integer = 0
+        {%- elif dtype == "boolean" %}
+    t.Boolean = false
+        {%- else %}
+    t.{{ dtype | capitalize }} = {{ dtype }}{}
+        {%- endif %}
+    {%- endfor %}
+
+    {%- for dtype in attr.dtypes %}
+        {%- if dtype in object_names %}
+    var objectValue {{ dtype }}
+    if err := json.Unmarshal(data, &objectValue); err == nil {
+        t.Object = objectValue
+        return nil
+    }
+        {%- elif dtype == "string" %}
+    var stringValue string
+    if err := json.Unmarshal(data, &stringValue); err == nil {
+        t.String = stringValue
+        return nil
+    }
+        {%- elif dtype == "float" %}
+    var floatValue float64
+    if err := json.Unmarshal(data, &floatValue); err == nil {
+        t.Float = floatValue
+        return nil
+    }
+        {%- elif dtype == "integer" %}
+    var intValue int64
+    if err := json.Unmarshal(data, &intValue); err == nil {
+        t.Integer = intValue
+        return nil
+    }
+        {%- elif dtype == "boolean" %}
+    var boolValue bool
+    if err := json.Unmarshal(data, &boolValue); err == nil {
+        t.Boolean = boolValue
+        return nil
+    }
+        {%- else %}
+    var value {{ dtype }}
+    if err := json.Unmarshal(data, &value); err == nil {
+        t.{{ dtype | capitalize }} = value
+        return nil
+    }
+        {%- endif %}
+    {%- endfor %}
+    return fmt.Errorf("{{ object.name }}{{ attr.name | capitalize }}Type: data is neither {{ attr.dtypes | join(', ') }}")
+}
+
+// MarshalJSON implements custom JSON marshaling for {{ object.name }}{{ attr.name | capitalize }}Type
+func (t {{ object.name }}{{ attr.name | capitalize }}Type) MarshalJSON() ([]byte, error) {
+    {%- for dtype in attr.dtypes %}
+        {%- if dtype in object_names %}
+    if t.Object != nil {
+        return json.Marshal(t.Object)
+    }
+        {%- elif dtype == "string" %}
+    if t.String != nil {
+        return json.Marshal(*t.String)
+    }
+        {%- elif dtype == "float" %}
+    if t.Float != nil {
+        return json.Marshal(*t.Float)
+    }
+        {%- elif dtype == "integer" %}
+    if t.Integer != nil {
+        return json.Marshal(*t.Integer)
+    }
+        {%- elif dtype == "boolean" %}
+    if t.Boolean != nil {
+        return json.Marshal(*t.Boolean)
+    }
+        {%- else %}
+    if t.{{ dtype | capitalize }} != nil {
+        return json.Marshal(*t.{{ dtype | capitalize }})
+    }
+        {%- endif %}
+    {%- endfor %}
+    return []byte("null"), nil
+}
+    {%- endif %}
+    {%- endfor %}
+{%- endfor %}

--- a/templates/graphql.jinja
+++ b/templates/graphql.jinja
@@ -1,0 +1,96 @@
+# This file contains GraphQL type definitions.
+# 
+# WARNING: This is an auto-generated file.
+# Do not edit directly - any changes will be overwritten.
+
+{% macro get_type(attr) %}
+  {%- if attr.dtypes | length > 1 -%}
+    {%- for dtype in attr.dtypes -%}
+      {%- if dtype in object_names -%}
+        {{- dtype -}}
+      {%- else -%}
+        {{- dtype -}}
+      {%- endif -%}
+      {%- if not loop.last %} | {% endif -%}
+    {%- endfor -%}
+  {%- else -%}
+    {%- if attr.dtypes[0] in object_names -%}
+      {{- attr.dtypes[0] -}}
+    {%- else -%}
+      {{- attr.dtypes[0] -}}
+    {%- endif -%}
+  {%- endif -%}
+{% endmacro %}
+
+{% macro wrap_type(dtype, attr) %}
+  {%- if attr.multiple -%}
+  [{{ dtype }}]
+  {%- else -%}
+  {{ dtype }}
+  {%- endif -%}
+  {%- if attr.required -%}!{%- endif -%}
+{% endmacro %}
+
+# Scalar wrapper types
+{%- for object in objects -%}
+  {%- for attr in object.attributes -%}
+    {%- if attr.dtypes | length > 1 -%}
+      {%- for dtype in attr.dtypes -%}
+        {%- if dtype not in object_names %}
+type {{ dtype }}Value {
+  value: {{ dtype }}!
+}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor %}
+
+# Union type definitions
+{%- for object in objects -%}
+  {%- for attr in object.attributes -%}
+    {%- if attr.dtypes | length > 1 %}
+union {{ object.name }}{{ attr.name | capitalize }} = {% for dtype in attr.dtypes %}{% if dtype in object_names %}{{ dtype }}{% else %}{{ dtype }}Value{% endif %}{% if not loop.last %} | {% endif %}{% endfor %}
+
+    {%- endif -%}
+  {%- endfor -%}
+{%- endfor %}
+
+# {% if title %}{{ title }}{% else %}Model{% endif %} Type definitions
+{%- for object in objects %}
+type {{ object.name }} {
+  {%- for attr in object.attributes %}
+  {{ attr.name }}: {% if attr.dtypes | length > 1 -%}
+  {{ wrap_type(object.name + attr.name | capitalize, attr) }}
+  {%- else -%}
+  {{ wrap_type(get_type(attr), attr) }}
+  {%- endif -%}
+  {%- endfor %}
+}
+{% endfor %}
+
+{%- if enums | length > 0 %}
+# {% if title %}{{ title }}{% else %}Model{% endif %} Enum definitions
+{%- for enum in enums %}
+enum {{ enum.name }} {
+  {%- for key, value in enum.mappings | dictsort %}
+  {{ key }} # {{ value }}
+  {%- endfor %}
+}
+{% endfor %}
+{%- endif %}
+
+# Query type definitions
+type Query {
+  {%- for object in objects %}
+
+  # {{ object.name }} queries
+  {{ object.name | lower }}(id: ID!): {{ object.name }}
+  all{{ object.name }}s: [{{ object.name }}]
+  {%- for attr in object.attributes %}
+  {%- if not attr.multiple and attr.dtypes | length == 1 and attr.dtypes[0] not in object_names %}
+  {{ object.name | lower }}By{{ attr.name | capitalize }}({{ attr.name }}: {{ get_type(attr) }}): [{{ object.name }}]
+  {%- endif %}
+  {%- endfor %}
+  {%- endfor %}
+}

--- a/templates/protobuf.jinja
+++ b/templates/protobuf.jinja
@@ -1,0 +1,80 @@
+/**
+ * This file contains Protocol Buffer message definitions.
+ * 
+ * Protocol Buffers (protobuf) is Google's language-neutral, platform-neutral,
+ * extensible mechanism for serializing structured data.
+ * 
+ * WARNING: This is an auto-generated file.
+ * Do not edit directly - any changes will be overwritten.
+ */
+
+{% macro get_type(attr) %}
+  {%- if attr.dtypes | length > 1 -%}
+  OneOf{{ attr.name | pascal_case }}
+  {%- elif attr.dtypes[0] in object_names -%}
+  {{ attr.dtypes[0] }}
+  {%- elif attr.dtypes[0] in enum_names -%}
+  {{ attr.dtypes[0] }}
+  {%- elif attr.dtypes[0] == "string" -%}
+  string
+  {%- elif attr.dtypes[0] == "float" -%}
+  double
+  {%- elif attr.dtypes[0] == "int" -%}
+  int32
+  {%- elif attr.dtypes[0] == "bool" -%}
+  bool
+  {%- else -%}
+  {{ attr.dtypes[0] }}
+  {%- endif -%}
+{% endmacro %}
+
+{% macro field_rule(attr) %}
+  {%- if attr.multiple -%}
+  repeated 
+  {%- elif attr.required is false -%}
+  optional  
+  {%- endif -%}
+{% endmacro %}
+
+syntax = "proto3";
+
+package {% if title %}{{ title | lower }}{% else %}model{% endif %};
+
+{%- if enums | length > 0 %}
+//
+// {% if title %}{{ title }}{% else %}Model{% endif %} Enum definitions
+//
+{%- for enum in enums %}
+enum {{ enum.name }} {
+  {%- for key, value in enum.mappings | dictsort %}
+  {{ key }} = {{ loop.index0 }}; // {{ value }}
+  {%- endfor %}
+}
+{%- endfor %}
+{% endif %}
+
+//
+// {% if title %}{{ title }}{% else %}Model{% endif %} Message definitions
+//
+// OneOf type definitions for attributes with multiple types
+{%- for object in objects %}
+{%- for attr in object.attributes %}
+{%- if attr.dtypes | length > 1 %}
+message OneOf{{ attr.name | pascal_case }} {
+  oneof value {
+    {%- for dtype in attr.dtypes %}
+    {{ get_type({'dtypes': [dtype]}) }} {{ dtype | snake_case }}_value = {{ loop.index }};
+    {%- endfor %}
+  }
+}
+{% endif %}
+{%- endfor %}
+message {{ object.name }} {
+  {%- for attr in object.attributes %}
+  {%- if attr.docstring %}
+  // {{ wrap(attr.docstring, 70, "", "  // ", None) }}
+  {%- endif %}
+  {{ field_rule(attr) }}{%- if not attr.required %} {% endif -%}{{ get_type(attr) }} {{ attr.name | snake_case }} = {{ loop.index }};
+  {%- endfor %}
+}
+{% endfor %}

--- a/templates/python-dataclass.jinja
+++ b/templates/python-dataclass.jinja
@@ -1,3 +1,27 @@
+"""
+This file contains dataclass definitions for data validation.
+
+Dataclasses are a built-in Python library that provides a way to define data models
+with type hints and automatic serialization to JSON.
+
+Usage example:
+```python
+from my_model import MyModel
+
+# Validates data at runtime
+my_model = MyModel(name="John", age=30)
+
+# Type-safe - my_model has correct type hints
+print(my_model.name)
+```
+
+For more information see:
+https://docs.python.org/3/library/dataclasses.html
+
+WARNING: This is an auto-generated file.
+Do not edit directly - any changes will be overwritten.
+"""
+
 {#
     This macro determines whether a given attributes default is a string
 #}

--- a/templates/python-macros.jinja
+++ b/templates/python-macros.jinja
@@ -11,6 +11,9 @@
             default_factory=list,
             {% endif -%}
             tag="{{ xml_tag(attr.xml) }}",
+            {% if attr.docstring | length > 0 -%}
+            description="""{{ wrap(attr.docstring, 80, "", "            ", None ) }}""",
+            {% endif -%}
             json_schema_extra={{ create_options(attr.options, attr.term) }}
         )
 {% endmacro %}

--- a/templates/python-pydantic-xml.jinja
+++ b/templates/python-pydantic-xml.jinja
@@ -1,3 +1,34 @@
+"""
+This file contains Pydantic XML model definitions for data validation.
+
+Pydantic is a data validation library that uses Python type annotations.
+It allows you to define data models with type hints that are validated
+at runtime while providing static type checking.
+
+Usage example:
+```python
+from my_model import MyModel
+
+# Validates data at runtime
+my_model = MyModel(name="John", age=30)
+
+# Type-safe - my_model has correct type hints
+print(my_model.name)
+
+# Will raise error if validation fails
+try:
+    MyModel(name="", age=30)
+except ValidationError as e:
+    print(e)
+```
+
+For more information see:
+https://pydantic-xml.readthedocs.io/en/latest/
+
+WARNING: This is an auto-generated file.
+Do not edit directly - any changes will be overwritten.
+"""
+
 {% import "python-macros.jinja" as utils %}
 
 ## This is a generated file. Do not modify it manually!
@@ -7,6 +38,9 @@ from typing import Dict, List, Optional
 from uuid import uuid4
 from datetime import date, datetime
 from xml.dom import minidom
+{% if enums | length > 0 -%}
+from enum import Enum
+{%- endif %}
 
 from lxml.etree import _Element
 from pydantic import PrivateAttr, model_validator

--- a/templates/python-pydantic.jinja
+++ b/templates/python-pydantic.jinja
@@ -1,3 +1,34 @@
+"""
+This file contains Pydantic model definitions for data validation.
+
+Pydantic is a data validation library that uses Python type annotations.
+It allows you to define data models with type hints that are validated
+at runtime while providing static type checking.
+
+Usage example:
+```python
+from my_model import MyModel
+
+# Validates data at runtime
+my_model = MyModel(name="John", age=30)
+
+# Type-safe - my_model has correct type hints
+print(my_model.name)
+
+# Will raise error if validation fails
+try:
+    MyModel(name="", age=30)
+except ValidationError as e:
+    print(e)
+```
+
+For more information see:
+https://docs.pydantic.dev/
+
+WARNING: This is an auto-generated file.
+Do not edit directly - any changes will be overwritten.
+"""
+
 {#
     This macro determines whether a given attributes default is a string
 #}

--- a/templates/rust.jinja
+++ b/templates/rust.jinja
@@ -1,0 +1,125 @@
+{# Helper macros #}
+{% macro is_multiple(attr) %}
+    {%- if attr.multiple -%}Vec<{%- endif -%}
+{% endmacro %}
+
+{% macro is_multiple_end(attr) %}
+    {%- if attr.multiple -%}>{%- endif -%}
+{% endmacro %}
+
+{% macro get_type(attr, parent_name) %}
+    {%- if attr.dtypes | length > 1 -%}
+    {{ parent_name }}{{ attr.name | capitalize }}Type
+    {%- elif attr.dtypes[0] in object_names -%}
+    {{ attr.dtypes[0] }}
+    {%- elif attr.dtypes[0] == "string" -%}
+    String
+    {%- elif attr.dtypes[0] == "float" -%}
+    f64
+    {%- elif attr.dtypes[0] == "integer" -%}
+    i64
+    {%- elif attr.dtypes[0] == "boolean" -%}
+    bool
+    {%- else -%}
+    {{ attr.dtypes[0] }}
+    {%- endif -%}
+{% endmacro %}
+
+{% macro wrap_type(attr, parent_name) %}
+    {%- if attr.required is false -%}
+    Option<{{ is_multiple(attr) }}{{ get_type(attr, parent_name) }}{{ is_multiple_end(attr) }}>
+    {%- else -%}
+    {{ is_multiple(attr) }}{{ get_type(attr, parent_name) }}{{ is_multiple_end(attr) }}
+    {%- endif -%}
+{% endmacro %}
+
+//! This file contains Rust struct definitions with serde serialization.
+//! 
+//! WARNING: This is an auto-generated file.
+//! Do not edit directly - any changes will be overwritten.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// JSON-LD base types
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct JsonLdContext(pub HashMap<String, serde_json::Value>);
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct JsonLd {
+    #[serde(rename = "@context", skip_serializing_if = "Option::is_none")]
+    pub context: Option<JsonLdContext>,
+    #[serde(rename = "@id", skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "@type", skip_serializing_if = "Option::is_none")]
+    pub type_: Option<String>,
+}
+
+//
+// {% if title %}{{ title }}{% else %}Model{% endif %} Type definitions
+//
+{%- for object in objects %}
+
+{%- if object.docstring %}
+/// {{ wrap(object.docstring, 70, "", "/// ", None) }}
+{%- endif %}
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct {{ object.name }} {
+    #[serde(flatten)]
+    pub json_ld: JsonLd,
+    {%- for attr in object.attributes %}
+    {%- if attr.docstring %}
+    /// {{ wrap(attr.docstring, 70, "", "    /// ", None) }}
+    {%- endif %}
+    {%- if attr.required is false %}
+    #[serde(skip_serializing_if = "Option::is_none")]
+    {%- endif %}
+    pub {{ attr.name }}: {{ wrap_type(attr, object.name) }},
+    {%- endfor %}
+}
+{% endfor %}
+
+{%- if enums | length > 0 %}
+//
+// {% if title %}{{ title }}{% else %}Model{% endif %} Enum definitions
+//
+{%- for enum in enums %}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum {{ enum.name }} {
+    {%- for key, value in enum.mappings | dictsort %}
+    #[serde(rename = "{{ value }}")]
+    {{ key }},
+    {%- endfor %}
+}
+{% endfor %}
+{%- endif %}
+
+//
+// Enum definitions for attributes with multiple types
+//
+{%- for object in objects %}
+{%- for attr in object.attributes %}
+{%- if attr.dtypes | length > 1 %}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum {{ object.name }}{{ attr.name | capitalize }}Type {
+    {%- for dtype in attr.dtypes %}
+    {%- if dtype in object_names %}
+    Object({{ dtype }}),
+    {%- elif dtype == "string" %}
+    String(String),
+    {%- elif dtype == "float" %}
+    Float(f64),
+    {%- elif dtype == "integer" %}
+    Integer(i64),
+    {%- elif dtype == "boolean" %}
+    Boolean(bool),
+    {%- else %}
+    {{ dtype | capitalize }}({{ dtype }}),
+    {%- endif %}
+    {%- endfor %}
+}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}

--- a/templates/typescript-zod.jinja
+++ b/templates/typescript-zod.jinja
@@ -1,0 +1,125 @@
+/**
+ * This file contains Zod schema definitions for data validation.
+ * 
+ * Zod is a TypeScript-first schema declaration and validation library.
+ * It allows you to create schemas that validate data at runtime while 
+ * providing static type inference.
+ * 
+ * Usage example:
+ * ```typescript
+ * import { TestSchema } from './schemas';
+ * 
+ * // Validates data at runtime
+ * const result = TestSchema.parse(data);
+ * 
+ * // Type-safe - result has correct TypeScript types
+ * console.log(result.name);
+ * 
+ * // Will throw error if validation fails
+ * try {
+ *   TestSchema.parse(invalidData);
+ * } catch (err) {
+ *   console.error(err);
+ * }
+ * ```
+ * 
+ * @see https://github.com/colinhacks/zod
+ * 
+ * WARNING: This is an auto-generated file.
+ * Do not edit directly - any changes will be overwritten.
+ */
+
+
+{% macro is_multiple(attr) %}
+  {%- if attr.multiple -%}[]{%- endif -%}
+{% endmacro %}
+
+{% macro get_type(attr) %}
+  {%- if attr.dtypes | length == 1 -%}
+    {%- if attr.dtypes[0] in object_names -%}
+    {{ attr.dtypes[0] }}
+    {%- else -%}
+    {{ attr.dtypes[0] }}
+    {%- endif -%}
+  {%- else -%}
+    union
+  {%- endif -%}
+{% endmacro %}
+
+{# New macros for Zod schema types #}
+{% macro zod_type(dtype, attr) %}
+  {%- if attr.dtypes | length > 1 -%}
+    z.union([
+      {%- for type in attr.dtypes -%}
+        {%- if type in object_names -%}
+        {{ type }}Schema
+        {%- elif type in enum_names -%}
+        {{ type }}Schema
+        {%- elif type == "float" -%}
+        z.number()
+        {%- else -%}
+        z.{{ type | lower }}()
+        {%- endif -%}
+        {%- if not loop.last %}, {% endif -%}
+      {%- endfor -%}
+    ])
+  {%- else -%}
+    {%- if dtype in object_names -%}
+    {{ dtype }}Schema
+    {%- elif dtype in enum_names -%}
+    {{ dtype }}Schema
+    {%- elif dtype == "float" -%}
+    z.number()
+    {%- else -%}
+    z.{{ dtype | lower }}()
+    {%- endif -%}
+  {%- endif -%}
+{% endmacro %}
+
+{% macro wrap_zod_type(dtype, attr) %}
+  {%- if attr.multiple -%}
+  z.array({{ zod_type(dtype, attr) }})
+  {%- elif attr.required is false -%}
+  {{ zod_type(dtype, attr) }}.nullable()
+  {%- else -%}
+  {{ zod_type(dtype, attr) }}
+  {%- endif -%}
+{% endmacro %}
+
+{# Code structure starts here #}
+import { z } from 'zod';
+
+// JSON-LD Types
+export const JsonLdContextSchema = z.record(z.any());
+
+export const JsonLdSchema = z.object({
+  '@context': JsonLdContextSchema.optional(),
+  '@id': z.string().optional(),
+  '@type': z.string().optional(),
+});
+
+// {% if title %}{{ title }}{% else %}Model{% endif %} Type definitions
+{%- for object in objects %}
+export const {{ object.name }}Schema = z.lazy(() => JsonLdSchema.extend({
+  {%- for attr in object.attributes %}
+  {{ attr.name }}: {{ wrap_zod_type(get_type(attr), attr) }}{% if attr.docstring %}.describe(`
+    {{ wrap(attr.docstring, 70, "", "    ", None) }}
+  `){% endif %},
+  {%- endfor %}
+}));
+
+export type {{ object.name }} = z.infer<typeof {{ object.name }}Schema>;
+{% endfor %}
+
+{%- if enums | length > 0 %}
+// {% if title %}{{ title }}{% else %}Model{% endif %} Enum definitions
+{%- for enum in enums %}
+export enum {{ enum.name }} {
+  {%- for key, value in enum.mappings | dictsort %}
+  {{ key }} = '{{ value }}',
+  {%- endfor %}
+}
+
+export const {{ enum.name }}Schema = z.nativeEnum({{ enum.name }});
+{% endfor %}
+{% endif %}

--- a/templates/typescript.jinja
+++ b/templates/typescript.jinja
@@ -81,7 +81,7 @@ export interface JsonLd {
 {% endif %}
 
 {%- for attr in object.attributes %}
-    * @param {{ attr.name }} {%- if attr.docstring %} - {{ wrap(attr.docstring, 70, "", "             ") }}{%- endif %}
+    * @param {{ attr.name }} {%- if attr.docstring %} - {{ wrap(attr.docstring, 70, "", "             ", None) }}{%- endif %}
 {%- endfor %}
 **/
 export interface {{ object.name }} extends JsonLd {
@@ -103,7 +103,7 @@ export const {{ object.name }}Codec = D.lazy("{{ object.name }}", () => D.struct
 {%- for enum in enums %}
 {%- if enum.docstring %}
 /**
- * {{ wrap(enum.docstring, 70, " ", "    ") }}
+ * {{ wrap(enum.docstring, 70, " ", "    ", None) }}
 **/
 {%- endif %}
 export enum {{ enum.name }} {

--- a/templates/xml-schema.jinja
+++ b/templates/xml-schema.jinja
@@ -42,7 +42,7 @@
             >
             <xs:annotation>
                 <xs:documentation>
-                    {{ attribute.docstring }}
+                    {{ wrap(attribute.docstring, 70, "", "                    ", None) }}
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -65,7 +65,7 @@
                 {%- if attribute.docstring | length > 0 %}
                 <xs:annotation>
                     <xs:documentation>
-                        {{ attribute.docstring }}
+                        {{ wrap(attribute.docstring, 70, "", "                        ", None) }}
                     </xs:documentation>
                 </xs:annotation>
                 {%- endif %}
@@ -82,7 +82,7 @@
             <xs:element name="{{attribute.name}}" type="{{attribute.dtypes[0]}}Type">
                 <xs:annotation>
                     <xs:documentation>
-                        {{ attribute.docstring }}
+                        {{ wrap(attribute.docstring, 70, "", "                        ", None) }}
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -99,7 +99,7 @@
             >
                 <xs:annotation>
                     <xs:documentation>
-                        {{ attribute.docstring }}
+                        {{ wrap(attribute.docstring, 70, "", "                        ", None) }}
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/tests/data/expected_golang.go
+++ b/tests/data/expected_golang.go
@@ -1,0 +1,86 @@
+// Package model contains Go struct definitions with JSON serialization.
+//
+// WARNING: This is an auto-generated file.
+// Do not edit directly - any changes will be overwritten.
+
+package model
+
+import (
+    "encoding/json"
+    "fmt"
+)
+
+//
+// Type definitions
+//
+
+// Test Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+// eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+// ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+// aliquip ex ea commodo consequat.
+type Test struct {
+        // The name of the test. This is a unique identifier that helps track
+        // individual test cases across the system. It should be
+        // descriptive and follow the standard naming conventions.
+        Name string `json:"name"`
+        Number TestNumberType `json:"number,omitempty"`
+        Test2 []Test2 `json:"test2,omitempty"`
+        Ontology Ontology `json:"ontology,omitempty"`
+}
+
+type Test2 struct {
+        Names []string `json:"names,omitempty"`
+        Number float64 `json:"number,omitempty"`
+}
+
+//
+// Enum definitions
+//
+type Ontology string
+
+const (
+    OntologyECO Ontology = "https://www.evidenceontology.org/term/"
+    OntologyGO Ontology = "https://amigo.geneontology.org/amigo/term/"
+    OntologySIO Ontology = "http://semanticscience.org/resource/"
+)
+
+//
+// Type definitions for attributes with multiple types
+//
+
+// TestNumberType represents a union type that can hold any of the following types:
+// - float
+// - string
+type TestNumberType struct {
+    Float float64
+    String string
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for TestNumberType
+func (t *TestNumberType) UnmarshalJSON(data []byte) error {
+    // Reset existing values
+    t.Float = 0
+    t.String = ""
+    var floatValue float64
+    if err := json.Unmarshal(data, &floatValue); err == nil {
+        t.Float = floatValue
+        return nil
+    }
+    var stringValue string
+    if err := json.Unmarshal(data, &stringValue); err == nil {
+        t.String = stringValue
+        return nil
+    }
+    return fmt.Errorf("TestNumberType: data is neither float, string")
+}
+
+// MarshalJSON implements custom JSON marshaling for TestNumberType
+func (t TestNumberType) MarshalJSON() ([]byte, error) {
+    if t.Float != nil {
+        return json.Marshal(*t.Float)
+    }
+    if t.String != nil {
+        return json.Marshal(*t.String)
+    }
+    return []byte("null"), nil
+}

--- a/tests/data/expected_graphql.graphql
+++ b/tests/data/expected_graphql.graphql
@@ -1,0 +1,52 @@
+# This file contains GraphQL type definitions.
+#
+# WARNING: This is an auto-generated file.
+# Do not edit directly - any changes will be overwritten.
+
+
+# Scalar wrapper types
+type FloatValue {
+  value: Float!
+}
+type StringValue {
+  value: String!
+}
+
+# Union type definitions
+union TestNumber = FloatValue | StringValue
+
+# Model Type definitions
+type Test {
+  name: String!
+  number: TestNumber
+  test2: [Test2]
+  ontology: Ontology
+}
+
+type Test2 {
+  names: [String]
+  number: Float
+}
+
+# Model Enum definitions
+enum Ontology {
+  ECO # https://www.evidenceontology.org/term/
+  GO # https://amigo.geneontology.org/amigo/term/
+  SIO # http://semanticscience.org/resource/
+}
+
+
+# Query type definitions
+type Query {
+
+  # Test queries
+  test(id: ID!): Test
+  allTests: [Test]
+  testByName(name: String): [Test]
+  testByOntology(ontology: Ontology): [Test]
+
+  # Test2 queries
+  test2(id: ID!): Test2
+  allTest2s: [Test2]
+  test2ByNumber(number: Float): [Test2]
+}

--- a/tests/data/expected_internal_schema.json
+++ b/tests/data/expected_internal_schema.json
@@ -10,7 +10,7 @@
           "dtypes": [
             "string"
           ],
-          "docstring": "The name of the test.",
+          "docstring": "The name of the test. This is a unique identifier that helps track individual test cases across the system. It should be descriptive and follow the standard naming conventions.",
           "options": [],
           "term": "schema:hello",
           "required": true,
@@ -20,14 +20,14 @@
           },
           "is_enum": false,
           "position": {
-            "line": 13,
+            "line": 15,
             "column": {
               "start": 1,
               "end": 11
             },
             "offset": {
-              "start": 166,
-              "end": 458
+              "start": 399,
+              "end": 864
             }
           }
         },
@@ -36,7 +36,8 @@
           "multiple": false,
           "is_id": false,
           "dtypes": [
-            "float"
+            "float",
+            "string"
           ],
           "docstring": "",
           "options": [],
@@ -49,14 +50,14 @@
           },
           "is_enum": false,
           "position": {
-            "line": 18,
+            "line": 22,
             "column": {
               "start": 1,
               "end": 9
             },
             "offset": {
-              "start": 275,
-              "end": 355
+              "start": 673,
+              "end": 761
             }
           }
         },
@@ -77,14 +78,14 @@
           },
           "is_enum": false,
           "position": {
-            "line": 23,
+            "line": 27,
             "column": {
               "start": 1,
               "end": 8
             },
             "offset": {
-              "start": 355,
-              "end": 427
+              "start": 761,
+              "end": 833
             }
           }
         },
@@ -105,19 +106,19 @@
           },
           "is_enum": true,
           "position": {
-            "line": 27,
+            "line": 31,
             "column": {
               "start": 1,
               "end": 11
             },
             "offset": {
-              "start": 427,
-              "end": 458
+              "start": 833,
+              "end": 864
             }
           }
         }
       ],
-      "docstring": "",
+      "docstring": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
       "position": {
         "line": 11,
         "column": {
@@ -150,14 +151,14 @@
           },
           "is_enum": false,
           "position": {
-            "line": 32,
+            "line": 36,
             "column": {
               "start": 1,
               "end": 8
             },
             "offset": {
-              "start": 469,
-              "end": 613
+              "start": 875,
+              "end": 1019
             }
           }
         },
@@ -183,28 +184,28 @@
           },
           "is_enum": false,
           "position": {
-            "line": 36,
+            "line": 40,
             "column": {
               "start": 1,
               "end": 9
             },
             "offset": {
-              "start": 533,
-              "end": 613
+              "start": 939,
+              "end": 1019
             }
           }
         }
       ],
       "docstring": "",
       "position": {
-        "line": 30,
+        "line": 34,
         "column": {
           "start": 1,
           "end": 10
         },
         "offset": {
-          "start": 458,
-          "end": 468
+          "start": 864,
+          "end": 874
         }
       }
     }
@@ -219,14 +220,14 @@
       },
       "docstring": "",
       "position": {
-        "line": 45,
+        "line": 49,
         "column": {
           "start": 1,
           "end": 13
         },
         "offset": {
-          "start": 630,
-          "end": 643
+          "start": 1036,
+          "end": 1049
         }
       }
     }

--- a/tests/data/expected_mkdocs.md
+++ b/tests/data/expected_mkdocs.md
@@ -29,14 +29,14 @@ This page provides comprehensive information about the structure and components 
 
 
 ### Test
-
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
 __name__* `string`
 
-- The name of the test.
+- The name of the test. This is a unique identifier that helps track individual test cases across the system. It should be descriptive and follow the standard naming conventions.
 
 
-__number__ `float`
+__number__ `float``string`
 
 
 - `Default`: 1.0

--- a/tests/data/expected_proto.proto
+++ b/tests/data/expected_proto.proto
@@ -1,0 +1,49 @@
+/**
+ * This file contains Protocol Buffer message definitions.
+ *
+ * Protocol Buffers (protobuf) is Google's language-neutral, platform-neutral,
+ * extensible mechanism for serializing structured data.
+ *
+ * WARNING: This is an auto-generated file.
+ * Do not edit directly - any changes will be overwritten.
+ */
+
+
+syntax = "proto3";
+
+package model;
+//
+// Model Enum definitions
+//
+enum Ontology {
+  ECO = 0; // https://www.evidenceontology.org/term/
+  GO = 1; // https://amigo.geneontology.org/amigo/term/
+  SIO = 2; // http://semanticscience.org/resource/
+}
+
+
+//
+// Model Message definitions
+//
+// OneOf type definitions for attributes with multiple types
+message OneOfNumber {
+  oneof value {
+    double float_value = 1;
+    string string_value = 2;
+  }
+}
+
+message Test {
+  // The name of the test. This is a unique identifier that helps track
+  // individual test cases across the system. It should be descriptive
+  // and follow the standard naming conventions.
+  string name = 1;
+  optional OneOfNumber number = 2;
+  repeated Test2 test_2 = 3;
+  optional Ontology ontology = 4;
+}
+
+message Test2 {
+  repeated string names = 1;
+  optional double number = 2;
+}

--- a/tests/data/expected_protobuf.proto
+++ b/tests/data/expected_protobuf.proto
@@ -1,0 +1,49 @@
+/**
+ * This file contains Protocol Buffer message definitions.
+ *
+ * Protocol Buffers (protobuf) is Google's language-neutral, platform-neutral,
+ * extensible mechanism for serializing structured data.
+ *
+ * WARNING: This is an auto-generated file.
+ * Do not edit directly - any changes will be overwritten.
+ */
+
+
+syntax = "proto3";
+
+package model;
+//
+// Model Enum definitions
+//
+enum Ontology {
+  ECO = 0; // https://www.evidenceontology.org/term/
+  GO = 1; // https://amigo.geneontology.org/amigo/term/
+  SIO = 2; // http://semanticscience.org/resource/
+}
+
+
+//
+// Model Message definitions
+//
+// OneOf type definitions for attributes with multiple types
+message OneOfNumber {
+  oneof value {
+    double float_value = 1;
+    string string_value = 2;
+  }
+}
+
+message Test {
+  // The name of the test. This is a unique identifier that helps track
+  // individual test cases across the system. It should be descriptive
+  // and follow the standard naming conventions.
+  string name = 1;
+  optional OneOfNumber number = 2;
+  repeated Test2 test_2 = 3;
+  optional Ontology ontology = 4;
+}
+
+message Test2 {
+  repeated string names = 1;
+  optional double number = 2;
+}

--- a/tests/data/expected_pydantic.py
+++ b/tests/data/expected_pydantic.py
@@ -1,3 +1,35 @@
+"""
+This file contains Pydantic model definitions for data validation.
+
+Pydantic is a data validation library that uses Python type annotations.
+It allows you to define data models with type hints that are validated
+at runtime while providing static type checking.
+
+Usage example:
+```python
+from my_model import MyModel
+
+# Validates data at runtime
+my_model = MyModel(name="John", age=30)
+
+# Type-safe - my_model has correct type hints
+print(my_model.name)
+
+# Will raise error if validation fails
+try:
+    MyModel(name="", age=30)
+except ValidationError as e:
+    print(e)
+```
+
+For more information see:
+https://docs.pydantic.dev/
+
+WARNING: This is an auto-generated file.
+Do not edit directly - any changes will be overwritten.
+"""
+
+
 ## This is a generated file. Do not modify it manually!
 
 from __future__ import annotations

--- a/tests/data/expected_python_dc.py
+++ b/tests/data/expected_python_dc.py
@@ -1,3 +1,28 @@
+"""
+This file contains dataclass definitions for data validation.
+
+Dataclasses are a built-in Python library that provides a way to define data models
+with type hints and automatic serialization to JSON.
+
+Usage example:
+```python
+from my_model import MyModel
+
+# Validates data at runtime
+my_model = MyModel(name="John", age=30)
+
+# Type-safe - my_model has correct type hints
+print(my_model.name)
+```
+
+For more information see:
+https://docs.python.org/3/library/dataclasses.html
+
+WARNING: This is an auto-generated file.
+Do not edit directly - any changes will be overwritten.
+"""
+
+
 ## This is a generated file. Do not modify it manually!
 
 from __future__ import annotations

--- a/tests/data/expected_python_pydantic_xml.py
+++ b/tests/data/expected_python_pydantic_xml.py
@@ -1,3 +1,35 @@
+"""
+This file contains Pydantic XML model definitions for data validation.
+
+Pydantic is a data validation library that uses Python type annotations.
+It allows you to define data models with type hints that are validated
+at runtime while providing static type checking.
+
+Usage example:
+```python
+from my_model import MyModel
+
+# Validates data at runtime
+my_model = MyModel(name="John", age=30)
+
+# Type-safe - my_model has correct type hints
+print(my_model.name)
+
+# Will raise error if validation fails
+try:
+    MyModel(name="", age=30)
+except ValidationError as e:
+    print(e)
+```
+
+For more information see:
+https://pydantic-xml.readthedocs.io/en/latest/
+
+WARNING: This is an auto-generated file.
+Do not edit directly - any changes will be overwritten.
+"""
+
+
 ## This is a generated file. Do not modify it manually!
 
 from __future__ import annotations
@@ -5,6 +37,7 @@ from typing import Dict, List, Optional
 from uuid import uuid4
 from datetime import date, datetime
 from xml.dom import minidom
+from enum import Enum
 
 from lxml.etree import _Element
 from pydantic import PrivateAttr, model_validator
@@ -17,10 +50,13 @@ class Test(
 ):
     name: str = attr(
             tag="name",
+            description="""The name of the test. This is a unique identifier that helps track individual
+            test cases across the system. It should be descriptive and follow
+            the standard naming conventions.""",
             json_schema_extra=dict(term = "schema:hello",)
         )
 
-    number: Optional[float] = attr(
+    number: Union[None,float,str] = attr(
             default=1.0,
             tag="number",
             json_schema_extra=dict(term = "schema:one",)

--- a/tests/data/expected_rust.rs
+++ b/tests/data/expected_rust.rs
@@ -1,0 +1,79 @@
+//! This file contains Rust struct definitions with serde serialization.
+//!
+//! WARNING: This is an auto-generated file.
+//! Do not edit directly - any changes will be overwritten.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// JSON-LD base types
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct JsonLdContext(pub HashMap<String, serde_json::Value>);
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct JsonLd {
+    #[serde(rename = "@context", skip_serializing_if = "Option::is_none")]
+    pub context: Option<JsonLdContext>,
+    #[serde(rename = "@id", skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "@type", skip_serializing_if = "Option::is_none")]
+    pub type_: Option<String>,
+}
+
+//
+// Model Type definitions
+//
+/// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+/// eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+/// enim ad minim veniam, quis nostrud exercitation ullamco laboris
+/// nisi ut aliquip ex ea commodo consequat.
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Test {
+    #[serde(flatten)]
+    pub json_ld: JsonLd,
+    /// The name of the test. This is a unique identifier that helps track
+    /// individual test cases across the system. It should be
+    /// descriptive and follow the standard naming conventions.
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number: Option<TestNumberType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test2: Option<Vec<Test2>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ontology: Option<Ontology>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct Test2 {
+    #[serde(flatten)]
+    pub json_ld: JsonLd,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub names: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub number: Option<f64>,
+}
+
+//
+// Model Enum definitions
+//
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Ontology {
+    #[serde(rename = "https://www.evidenceontology.org/term/")]
+    ECO,
+    #[serde(rename = "https://amigo.geneontology.org/amigo/term/")]
+    GO,
+    #[serde(rename = "http://semanticscience.org/resource/")]
+    SIO,
+}
+
+
+//
+// Enum definitions for attributes with multiple types
+//
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TestNumberType {
+    Float(f64),
+    String(String),
+}

--- a/tests/data/expected_typescript.ts
+++ b/tests/data/expected_typescript.ts
@@ -23,7 +23,14 @@ export interface JsonLd {
 
 // none Type definitions
 /**
-    * @param name - The name of the test.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+    eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+    enim ad minim veniam, quis nostrud exercitation ullamco laboris
+    nisi ut aliquip ex ea commodo consequat.
+
+    * @param name - The name of the test. This is a unique identifier that helps track
+             individual test cases across the system. It should be
+             descriptive and follow the standard naming conventions.
     * @param number
     * @param test2
     * @param ontology

--- a/tests/data/expected_typescript_zod.ts
+++ b/tests/data/expected_typescript_zod.ts
@@ -1,0 +1,72 @@
+/**
+ * This file contains Zod schema definitions for data validation.
+ *
+ * Zod is a TypeScript-first schema declaration and validation library.
+ * It allows you to create schemas that validate data at runtime while
+ * providing static type inference.
+ *
+ * Usage example:
+ * ```typescript
+ * import { TestSchema } from './schemas';
+ *
+ * // Validates data at runtime
+ * const result = TestSchema.parse(data);
+ *
+ * // Type-safe - result has correct TypeScript types
+ * console.log(result.name);
+ *
+ * // Will throw error if validation fails
+ * try {
+ *   TestSchema.parse(invalidData);
+ * } catch (err) {
+ *   console.error(err);
+ * }
+ * ```
+ *
+ * @see https://github.com/colinhacks/zod
+ *
+ * WARNING: This is an auto-generated file.
+ * Do not edit directly - any changes will be overwritten.
+ */
+
+
+import { z } from 'zod';
+
+// JSON-LD Types
+export const JsonLdContextSchema = z.record(z.any());
+
+export const JsonLdSchema = z.object({
+  '@context': JsonLdContextSchema.optional(),
+  '@id': z.string().optional(),
+  '@type': z.string().optional(),
+});
+
+// Model Type definitions
+export const TestSchema = z.lazy(() => JsonLdSchema.extend({
+  name: z.string().describe(`
+    The name of the test. This is a unique identifier that helps track
+    individual test cases across the system. It should be descriptive
+    and follow the standard naming conventions.
+  `),
+  number: z.union([z.number(), z.string()]).nullable(),
+  test2: z.array(Test2Schema),
+  ontology: OntologySchema.nullable(),
+}));
+
+export type Test = z.infer<typeof TestSchema>;
+
+export const Test2Schema = z.lazy(() => JsonLdSchema.extend({
+  names: z.array(z.string()),
+  number: z.number().nullable(),
+}));
+
+export type Test2 = z.infer<typeof Test2Schema>;
+
+// Model Enum definitions
+export enum Ontology {
+  ECO = 'https://www.evidenceontology.org/term/',
+  GO = 'https://amigo.geneontology.org/amigo/term/',
+  SIO = 'http://semanticscience.org/resource/',
+}
+
+export const OntologySchema = z.nativeEnum(Ontology);

--- a/tests/data/expected_xml_schema.xsd
+++ b/tests/data/expected_xml_schema.xsd
@@ -20,7 +20,10 @@
         <xs:attribute name="name" type="xs:string"  use="required">
             <xs:annotation>
                 <xs:documentation>
-                    The name of the test.
+                    The name of the test. This is a unique identifier that helps track
+                    individual test cases across the system. It should
+                    be descriptive and follow the standard naming
+                    conventions.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute><xs:attribute name="number" type="xs:float" default="1.0"/>

--- a/tests/data/model.md
+++ b/tests/data/model.md
@@ -10,13 +10,17 @@ nsmap:
 
 ### Test
 
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
 - __name__
   - Type: Identifier
   - Term: schema:hello
-  - Description: The name of the test.
+  - Description: The name of the test. This is a unique identifier 
+    that helps track individual test cases across the system. 
+    It should be descriptive and follow the standard naming conventions.
   - XML: @name
 - number
-  - Type: float
+  - Type: float, string
   - Term: schema:one
   - XML: @number
   - Default: 1.0


### PR DESCRIPTION
* Fixed Python targets to include `description`
* Added new conversion targets
  * `Golang`
  * `Protobuf`
  * `Rust`
  * `Typescript-Zod` (Catered toward the [zod package](https://www.npmjs.com/package/zod))
  * `GraphQL`
 * Turned `Attribute`, `Object`, `XMLType` and `Frontmatter` structs from `pub(crate)` to `pub`
  * Can now be used for typing in other crates 