### PR TITLE
implement graph hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,12 +1222,13 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "mdmodels"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "assert_cmd",
  "clap",
  "colored",
  "convert_case",
+ "derive_builder",
  "getrandom",
  "gray_matter",
  "indexmap 2.7.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mdmodels"
 authors = ["Jan Range <jan.range@simtech.uni-stuttgart.de>"]
 description = "A tool to generate models, code and schemas from markdown files"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/FAIRChemistry/md-models"
@@ -44,6 +44,7 @@ petgraph = { version = "0.7.1", features = ["serde"] }
 schemars = { version = "0.8.22", features = ["derive_json_schema"] }
 json-patch = "4.0.0"
 thiserror = "2.0.12"
+derive_builder = "0.20.2"
 
 [features]
 default = ["openai"]

--- a/src/llm/extraction.rs
+++ b/src/llm/extraction.rs
@@ -103,7 +103,7 @@ pub async fn patch_openai(
 
     let mut dataset = query
         .dataset
-        .ok_or(format!("Dataset is required for patch operation"))?
+        .ok_or("Dataset is required for patch operation")?
         .clone();
 
     // Prepare the response format

--- a/src/llm/patch.rs
+++ b/src/llm/patch.rs
@@ -308,7 +308,7 @@ mod tests {
             .expect("Expected error");
 
         // Assert
-        assert!(result.len() > 0);
+        assert!(!result.is_empty());
 
         // Verify we get the expected validation error (missing required field)
         let error = result.first().unwrap();

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -540,8 +540,7 @@ mod tests {
 
     fn load_model() -> DataModel {
         let path = Path::new("tests/data/model.md");
-        let model = DataModel::from_markdown(path).expect("Failed to load model");
-        model
+        DataModel::from_markdown(path).expect("Failed to load model")
     }
 
     #[test]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -283,6 +283,7 @@ pub fn model_tree<T>(root_object: &Object, model: &DataModel) -> DiGraph<Node<T>
 /// # Returns
 ///
 /// A u64 hash value
+#[allow(dead_code)]
 pub(crate) fn hash_graph<T>(graph: &DiGraph<Node<T>, ()>) -> u64 {
     let mut hasher = DefaultHasher::new();
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -22,8 +22,10 @@
  */
 
 use std::collections::{HashMap, HashSet};
+use std::hash::{DefaultHasher, Hash, Hasher};
 
 use crate::{attribute::Attribute, datamodel::DataModel, object::Object};
+use petgraph::visit::EdgeRef;
 use petgraph::{
     graph::{DiGraph, NodeIndex},
     Direction,
@@ -184,6 +186,14 @@ pub enum Node<T> {
     },
 }
 
+impl<T> Hash for Node<T> {
+    // Hash the name and description of the node
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name().hash(state);
+        self.description().hash(state);
+    }
+}
+
 impl<T> Node<T> {
     /// Returns the name of the node, whether it's an Object or Attribute.
     ///
@@ -259,6 +269,43 @@ pub fn model_tree<T>(root_object: &Object, model: &DataModel) -> DiGraph<Node<T>
     process_queue(&mut graph, &mut queue, model);
 
     graph
+}
+
+/// Hashes a directed graph.
+///
+/// This function hashes a directed graph by first sorting the nodes and edges by their name and target/source indices, respectively.
+/// It then hashes each node and edge in turn, using their respective hash functions.
+///
+/// # Arguments
+///
+/// * `graph` - The directed graph to hash
+///
+/// # Returns
+///
+/// A u64 hash value
+pub(crate) fn hash_graph<T>(graph: &DiGraph<Node<T>, ()>) -> u64 {
+    let mut hasher = DefaultHasher::new();
+
+    let mut nodes = graph.node_weights().collect::<Vec<_>>();
+    nodes.sort_by_key(|n| n.name());
+
+    for node in nodes {
+        node.hash(&mut hasher);
+    }
+
+    let mut edges = graph.edge_references().collect::<Vec<_>>();
+    edges.sort_by_key(|e| (e.source().index(), e.target().index()));
+
+    for edge in edges {
+        {
+            edge.target().hash(&mut hasher);
+        }
+        {
+            edge.source().hash(&mut hasher);
+        }
+    }
+
+    hasher.finish()
 }
 
 /// Maps over a tree structure and collects nodes that match a given predicate into a HashMap.
@@ -567,5 +614,33 @@ mod tests {
                 assert_eq!(node.weight.data(), &None);
             }
         }
+    }
+
+    #[test]
+    fn test_hash_graph_same() {
+        let model = load_model();
+        let tree = model_tree::<()>(&model.objects[0], &model);
+        let hash = hash_graph(&tree);
+        println!("Hash: {}", hash);
+
+        let tree2 = model_tree::<()>(&model.objects[0], &model);
+        let hash2 = hash_graph(&tree2);
+        println!("Hash2: {}", hash2);
+
+        assert_eq!(hash, hash2);
+    }
+
+    #[test]
+    fn test_hash_graph_different() {
+        let model = load_model();
+        let tree = model_tree::<()>(&model.objects[0], &model);
+        let hash = hash_graph(&tree);
+        println!("Hash: {}", hash);
+
+        let tree2 = model_tree::<()>(&model.objects[1], &model);
+        let hash2 = hash_graph(&tree2);
+        println!("Hash2: {}", hash2);
+
+        assert_ne!(hash, hash2);
     }
 }


### PR DESCRIPTION
This PR implements a simple graph hashing workflow to distinguish two data models. This feature is used to create independent LanceDB tables that represent the set of vector embeddings for a given data model.