### PR TITLE
Fix zod OpenAI compat

### DIFF
--- a/templates/typescript-zod.jinja
+++ b/templates/typescript-zod.jinja
@@ -93,6 +93,7 @@
 {# Code structure starts here #}
 import { z } from 'zod';
 
+{% if "json-ld" in config %}
 // JSON-LD Types
 export const JsonLdContextSchema = z.record(z.string());
 
@@ -102,12 +103,17 @@ export const JsonLdSchema = z.object({
   '@type': z.string().optional().nullable(),
 });
 
+const BaseSchema = JsonLdSchema;
+{% else %}
+const BaseSchema = z.object({});
+{%- endif %}
+
 // {% if title %}{{ title }}{% else %}Model{% endif %} Type definitions
 {%- for object in objects %}
 {%- if object.docstring %}
 // {{ wrap(object.docstring, 70, "", "// ", None) }}
 {%- endif %}
-export const {{ object.name }}Schema = z.lazy(() => JsonLdSchema.extend({
+export const {{ object.name }}Schema = z.lazy(() => BaseSchema.extend({
   {%- for attr in object.attributes %}
   {{ attr.name }}: {{ wrap_zod_type(get_type(attr), attr) }}{% if attr.docstring %}.describe(`
     {{ wrap(attr.docstring, 70, "", "    ", None) }}

--- a/tests/data/expected_typescript_zod_json_ld.ts
+++ b/tests/data/expected_typescript_zod_json_ld.ts
@@ -33,7 +33,17 @@
 import { z } from 'zod';
 
 
-const BaseSchema = z.object({});
+// JSON-LD Types
+export const JsonLdContextSchema = z.record(z.string());
+
+export const JsonLdSchema = z.object({
+  '@context': JsonLdContextSchema.optional().nullable(),
+  '@id': z.string().optional().nullable(),
+  '@type': z.string().optional().nullable(),
+});
+
+const BaseSchema = JsonLdSchema;
+
 
 // Model Type definitions
 // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do


### PR DESCRIPTION
This pull request introduces support for generating TypeScript Zod schemas with optional JSON-LD fields, based on configuration. The main changes include conditional inclusion of JSON-LD types in the generated output, refactoring how configuration is handled in the code, and adding tests and expected output files to verify the new functionality.

**TypeScript Zod schema generation improvements:**

* Added conditional logic to `templates/typescript-zod.jinja` so that JSON-LD fields are included in the output only if `"json-ld"` is present in the config; otherwise, a minimal base schema is used. This affects how schemas are extended and makes the output more flexible. [[1]](diffhunk://#diff-fde0520f97f2c3f69c4e0f29f560b1f0b02642a97065d406f62e4e0dc7f4b3f0R96) [[2]](diffhunk://#diff-fde0520f97f2c3f69c4e0f29f560b1f0b02642a97065d406f62e4e0dc7f4b3f0R106-R116)

**Configuration handling and codebase refactoring:**

* Changed how config is managed in `src/exporters.rs` by ensuring a default empty config is used if none is provided, reducing errors during template rendering.
* Refactored the `convert_astropy_types` function to accept a direct config reference instead of an optional, simplifying function logic and usage.
* Updated logic for handling the `"gorm"` config option in Go template generation for consistency with the new config handling approach.

**Testing and documentation:**

* Added a new test for TypeScript Zod schema generation with JSON-LD config, and included the expected output file to ensure correctness. [[1]](diffhunk://#diff-a84c456a499435866b643d17059ce9cdaa61b47f892af30d03457900746f6a4aR979-R996) [[2]](diffhunk://#diff-0cee1f0177e58e79e6c015cd558b2d01f1dcaf65875d2691453d076133151b06R1-R80)
* Updated expected output files to reflect the new conditional schema generation, showing differences between standard and JSON-LD-enriched outputs. [[1]](diffhunk://#diff-5aaac07f20b7da206d35af18037e946921c2cb1fade7f355dcb3a3c9f4e0bd3bL35-R43) [[2]](diffhunk://#diff-5aaac07f20b7da206d35af18037e946921c2cb1fade7f355dcb3a3c9f4e0bd3bL62-R56) [[3]](diffhunk://#diff-0cee1f0177e58e79e6c015cd558b2d01f1dcaf65875d2691453d076133151b06R1-R80)